### PR TITLE
feature: `Compound` Deserializer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,10 @@ mod matter;
 // CH3(CH(CH3)CH2)CH3
 
 fn main() {
-    let chain: Chain = CompoundBuilder::new()
+    let cmp = CompoundBuilder::new()
         .linear_chain(6)
         .expect("Linear chain didn't work")
-        .build()
-        .into();
-    // dbg!(&cmp);
-    dbg!(&chain);
+        .build();
+    let chain = Chain::from(&cmp);
     dbg!(chain.to_string());
-    // Compound::parse("(CH3)2CH(CH3)ZnCl").unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::matter::compound::builder::CompoundBuilder;
+use crate::matter::compound::{builder::CompoundBuilder, deserializer::Chain};
 
 mod constants;
 mod matter;
@@ -7,11 +7,13 @@ mod matter;
 // CH3(CH(CH3)CH2)CH3
 
 fn main() {
-    let cmp = CompoundBuilder::new()
+    let chain: Chain = CompoundBuilder::new()
         .linear_chain(6)
         .expect("Linear chain didn't work")
-        .build();
+        .build()
+        .into();
     // dbg!(&cmp);
-    dbg!(cmp.to_string());
+    dbg!(&chain);
+    dbg!(chain.to_string());
     // Compound::parse("(CH3)2CH(CH3)ZnCl").unwrap();
 }

--- a/src/matter/compound/builder.rs
+++ b/src/matter/compound/builder.rs
@@ -61,29 +61,22 @@ impl CompoundBuilder {
             atom
         } else {
             panic!(
-                "Invalid atom index: {} (max index is {})",
+                "Invalid atom index: {} (length is {})",
                 idx,
-                if self.atoms.len() > 0 {
-                    self.atoms.len() - 1
-                } else {
-                    0
-                }
+                self.atoms.len(),
             );
         }
     }
 
+    #[allow(dead_code)]
     fn get_location_unsafe(&self, idx: usize) -> Location {
         if let Some(&loc) = self.locations.get(idx) {
             loc
         } else {
             panic!(
-                "Invalid location index: {} (max index is {})",
+                "Invalid location index: {} (length is {})",
                 idx,
-                if self.locations.len() > 0 {
-                    self.locations.len() - 1
-                } else {
-                    0
-                }
+                self.locations.len(),
             );
         }
     }

--- a/src/matter/compound/builder.rs
+++ b/src/matter/compound/builder.rs
@@ -63,7 +63,11 @@ impl CompoundBuilder {
             panic!(
                 "Invalid atom index: {} (max index is {})",
                 idx,
-                self.atoms.len() - 1
+                if self.atoms.len() > 0 {
+                    self.atoms.len() - 1
+                } else {
+                    0
+                }
             );
         }
     }
@@ -75,7 +79,11 @@ impl CompoundBuilder {
             panic!(
                 "Invalid location index: {} (max index is {})",
                 idx,
-                self.locations.len() - 1
+                if self.locations.len() > 0 {
+                    self.locations.len() - 1
+                } else {
+                    0
+                }
             );
         }
     }
@@ -113,7 +121,7 @@ impl CompoundBuilder {
             locations_to_idx.insert(loc, i);
         });
         for i in 0..backbone_len {
-            let base_loc = self.get_location_unsafe(i);
+            let base_loc = *locations.get(i).expect("Backbone loc not found.");
             let remote_atoms = self.get_remote_side_chains(i)?;
             if remote_atoms.len() > 4 {
                 todo!("Expanded octet prohibited (for now)");
@@ -198,7 +206,7 @@ impl CompoundBuilder {
             self.atoms.push(Atom::carbon());
             self.backbone.push(i);
         }
-        self.side_chains.clear();
+        // self.side_chains.clear();
         self.satisfy_backbone_octets();
         self.gen_locations()?;
         Ok(self)

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -1,0 +1,118 @@
+use std::{
+    collections::{BTreeSet, HashSet},
+    fmt,
+};
+
+#[derive(Clone, Debug)]
+pub enum Chain {
+    /// COMPOUND
+    Vec(Vec<Chain>, usize),
+    /// ATOMS
+    KV(String, usize),
+}
+
+#[allow(dead_code)]
+impl Chain {
+    fn incr_count_by(&mut self, count: usize) {
+        match self {
+            Self::Vec(_, c) => *c += count,
+            Self::KV(_, c) => *c += count,
+        }
+    }
+
+    fn get_count(&self) -> usize {
+        match self {
+            Self::Vec(_, c) => *c,
+            Self::KV(_, c) => *c,
+        }
+    }
+
+    pub fn group(&self) -> Self {
+        match self {
+            Self::Vec(chains, count) => {
+                let mut new_vec: Vec<Chain> = Vec::new();
+                for curr_chain in chains.iter() {
+                    let curr = curr_chain.group().clone(); // Recursion yay
+                    if new_vec.iter().any(|c| c.custom_eq(&curr)) {
+                        let last = new_vec
+                            .last_mut()
+                            .expect("Last chain should've been expected");
+                        last.incr_count_by(curr.get_count());
+                    } else {
+                        new_vec.push(curr);
+                    }
+                }
+                Self::Vec(new_vec, *count)
+            }
+            Self::KV(_, _) => self.clone(),
+        }
+    }
+
+    fn minimize(&self) {
+        // Convert redundant single-sized vectors into KV (if ATOM).
+    }
+
+    fn str(&self) -> String {
+        todo!()
+    }
+
+    fn custom_eq(&self, other: &Self) -> bool {
+        // IF vec, check everything is same
+        // If KV, check that identities are the same (Atoms)
+        //
+        // We have two implementations of equality, a custom equality and a full equality
+        match (self, other) {
+            (Self::KV(k_lhs, _), Self::KV(k_rhs, _)) => {
+                // Counts DO NOT matter (non-vec comparison)
+                k_lhs == k_rhs
+            }
+            (Self::Vec(_, _), Self::Vec(_, _)) => self == other, // EXACT checks
+            (_, _) => false,
+        }
+    }
+}
+
+impl PartialEq for Chain {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::KV(k_lhs, v_lhs), Self::KV(k_rhs, v_rhs)) => {
+                // Counts matter for side chains to be equal (vec comparison).
+                k_lhs == k_rhs && v_lhs == v_rhs
+            }
+            (Self::Vec(lhs, _), Self::Vec(rhs, _)) => {
+                // Exact side chain counts won't matter, their components do.
+                lhs.len() == rhs.len()
+                    && lhs.iter().all(|l| rhs.contains(l))
+                    && rhs.iter().all(|r| lhs.contains(r))
+            }
+            (_, _) => false,
+        }
+    }
+}
+
+impl fmt::Display for Chain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_grouping_test() {
+        // ((H5H5)(H5H5)) => ((H10)2)
+        let inner = Chain::Vec(
+            Vec::from([Chain::KV("H".into(), 5), Chain::KV("H".into(), 5)]),
+            1,
+        );
+        let outer = Vec::from([inner.clone(), inner]);
+        let lhs = Chain::Vec(outer, 1).group();
+        let rhs = Chain::Vec(
+            Vec::from([Chain::Vec(Vec::from([Chain::KV("H".into(), 10)]), 2)]),
+            1,
+        );
+        assert_eq!(lhs, rhs, "Grouping does not function correctly.")
+    }
+}

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -126,7 +126,7 @@ mod tests {
         let rhs = Chain::KV("H".into(), 20);
         assert_eq!(
             lhs, rhs,
-            "Grouping & minimizing dont not function correctly."
+            "Grouping & minimizing aren't functioning correctly."
         )
     }
 }

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -9,16 +9,14 @@ pub enum Chain {
 }
 
 impl Chain {
-    fn reversed(&self) -> Chain {
+    fn reversed(self) -> Chain {
         // Reverses order of chain
-        match self.clone().group().minimize(1) {
+        match self.group().minimize(1) {
             Self::KV(k, v) => Self::KV(k, v),
-            Self::Vec(v, c) => {
-                let mut reversed_vec = v.clone();
-                reversed_vec.reverse();
-                reversed_vec =
-                    reversed_vec.iter().map(|i| i.reversed()).collect();
-                Self::Vec(reversed_vec, c).group().minimize(1)
+            Self::Vec(mut v, c) => {
+                v.reverse();
+                v = v.into_iter().map(|i| i.reversed()).collect();
+                Self::Vec(v, c).group().minimize(1)
             }
         }
     }
@@ -310,7 +308,7 @@ mod tests {
         .reversed();
         assert_eq!(
             methane.to_string(),
-            "H4C".to_string(),
+            "H4C",
             "Compound reversing doesn't work"
         );
     }

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -11,7 +11,7 @@ pub enum Chain {
 impl Chain {
     fn reversed(&self) -> Chain {
         // Reverses order of chain
-        match self.group().minimize(1) {
+        match self.clone().group().minimize(1) {
             Self::KV(k, v) => Self::KV(k, v),
             Self::Vec(v, c) => {
                 let mut reversed_vec = v.clone();

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -178,4 +178,53 @@ mod tests {
             "Formula is not properly condensed."
         );
     }
+
+    #[test]
+    fn condense_tert_butanol() {
+        // HOC((CH3)(CH3)(CH3)) => HOC(CH3)3
+        let chain = Chain::Vec(
+            Vec::from([
+                Chain::Vec(
+                    Vec::from([
+                        Chain::KV("H".into(), 1),
+                        Chain::KV("O".into(), 1),
+                    ]),
+                    1,
+                ),
+                Chain::KV("C".into(), 1),
+                Chain::Vec(
+                    Vec::from([
+                        Chain::Vec(
+                            Vec::from([
+                                Chain::KV("C".into(), 1),
+                                Chain::KV("H".into(), 3),
+                            ]),
+                            1,
+                        ),
+                        Chain::Vec(
+                            Vec::from([
+                                Chain::KV("C".into(), 1),
+                                Chain::KV("H".into(), 3),
+                            ]),
+                            1,
+                        ),
+                        Chain::Vec(
+                            Vec::from([
+                                Chain::KV("C".into(), 1),
+                                Chain::KV("H".into(), 3),
+                            ]),
+                            1,
+                        ),
+                    ]),
+                    1,
+                ),
+            ]),
+            1,
+        );
+        assert_eq!(
+            chain.to_string(),
+            "HOC(CH3)3",
+            "Tert-butanol doesn't condense correctly"
+        );
+    }
 }

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -235,40 +235,30 @@ mod tests {
 
     #[test]
     fn condense_tert_butanol() {
-        // HOC((CH3)(CH3)(CH3)) => HOC(CH3)3
+        // HOC(CH3)(CH3)(CH3) => HOC(CH3)3
         let chain = Chain::Vec(
             Vec::from([
-                Chain::Vec(
-                    Vec::from([
-                        Chain::KV("H".into(), 1),
-                        Chain::KV("O".into(), 1),
-                    ]),
-                    1,
-                ),
+                Chain::KV("H".into(), 1),
+                Chain::KV("O".into(), 1),
                 Chain::KV("C".into(), 1),
                 Chain::Vec(
                     Vec::from([
-                        Chain::Vec(
-                            Vec::from([
-                                Chain::KV("C".into(), 1),
-                                Chain::KV("H".into(), 3),
-                            ]),
-                            1,
-                        ),
-                        Chain::Vec(
-                            Vec::from([
-                                Chain::KV("C".into(), 1),
-                                Chain::KV("H".into(), 3),
-                            ]),
-                            1,
-                        ),
-                        Chain::Vec(
-                            Vec::from([
-                                Chain::KV("C".into(), 1),
-                                Chain::KV("H".into(), 3),
-                            ]),
-                            1,
-                        ),
+                        Chain::KV("C".into(), 1),
+                        Chain::KV("H".into(), 3),
+                    ]),
+                    1,
+                ),
+                Chain::Vec(
+                    Vec::from([
+                        Chain::KV("C".into(), 1),
+                        Chain::KV("H".into(), 3),
+                    ]),
+                    1,
+                ),
+                Chain::Vec(
+                    Vec::from([
+                        Chain::KV("C".into(), 1),
+                        Chain::KV("H".into(), 3),
                     ]),
                     1,
                 ),
@@ -311,8 +301,6 @@ mod tests {
 
     #[test]
     fn condense_1_4_butanediol() {
-        // TODO: Make a function that creates a linear chain for Chain
-        //
         // HOCH2CH2CH2CH2OH => HO(CH2)4OH
         let hydroxyl_1 = Chain::Vec(
             Vec::from([Chain::KV("H".into(), 1), Chain::KV("O".into(), 1)]),

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -10,6 +10,20 @@ pub enum Chain {
 
 #[allow(dead_code)]
 impl Chain {
+    fn reversed(&self) -> Chain {
+        // Reverses order of chain
+        match self.group().minimize(1) {
+            Self::KV(k, v) => Self::KV(k, v),
+            Self::Vec(v, c) => {
+                let mut reversed_vec = v.clone();
+                reversed_vec.reverse();
+                reversed_vec =
+                    reversed_vec.iter().map(|i| i.reversed()).collect();
+                Self::Vec(reversed_vec, c).group().minimize(1)
+            }
+        }
+    }
+
     fn incr_count_by(&mut self, count: usize) {
         match self {
             Self::Vec(_, c) => *c += count,
@@ -234,6 +248,7 @@ mod tests {
 
     #[test]
     fn condense_butane() {
+        // CH3(CH2)(CH2)CH3 => CH3(CH2)2CH3
         let terminal_cs = Chain::Vec(
             Vec::from([Chain::KV("C".into(), 1), Chain::KV("H".into(), 3)]),
             1,
@@ -261,7 +276,6 @@ mod tests {
     #[test]
     fn condense_1_4_butanediol() {
         // TODO: Make a function that creates a linear chain for Chain
-        // TODO: Make reversed side chain function
         //
         // HOCH2CH2CH2CH2OH => HO(CH2)4OH
         let hydroxyl_1 = Chain::Vec(
@@ -292,5 +306,19 @@ mod tests {
             "HO(CH2)4OH",
             "Could not condense 1,4-butanediol into chemical formula"
         )
+    }
+
+    #[test]
+    fn test_reverse_with_methane() {
+        let methane = Chain::Vec(
+            Vec::from([Chain::KV("C".into(), 1), Chain::KV("H".into(), 4)]),
+            1,
+        )
+        .reversed();
+        assert_eq!(
+            methane.to_string(),
+            "H4C".to_string(),
+            "Compound reversing doesn't work"
+        );
     }
 }

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -178,17 +178,17 @@ impl fmt::Display for Chain {
     }
 }
 
-impl From<Compound> for Chain {
-    fn from(val: Compound) -> Self {
-        let mut vec: Vec<Self> = Vec::new();
+impl From<&Compound> for Chain {
+    fn from(val: &Compound) -> Self {
+        let mut chains = Vec::new();
         for &i in val.backbone.iter() {
             if val.has_side_chain(i) {
-                vec.push(Self::from_atom(&val, i));
+                chains.push(Self::from_atom(&val, i));
             } else {
-                vec.push(Self::KV(val.get_atom_unsafe(i).to_string(), 1));
+                chains.push(Self::KV(val.get_atom_unsafe(i).to_string(), 1));
             }
         }
-        Self::Vec(vec, 1).group().minimize()
+        Self::Vec(chains, 1).group().minimize()
     }
 }
 
@@ -355,6 +355,6 @@ mod tests {
             Deserialize functionality",
             )
             .build();
-        assert_eq!(Chain::from(hexane).to_string(), "CH3(CH2)4CH3")
+        assert_eq!(Chain::from(&hexane).to_string(), "CH3(CH2)4CH3")
     }
 }

--- a/src/matter/compound/deserializer.rs
+++ b/src/matter/compound/deserializer.rs
@@ -257,4 +257,40 @@ mod tests {
             "Failed to condense butane"
         )
     }
+
+    #[test]
+    fn condense_1_4_butanediol() {
+        // TODO: Make a function that creates a linear chain for Chain
+        // TODO: Make reversed side chain function
+        //
+        // HOCH2CH2CH2CH2OH => HO(CH2)4OH
+        let hydroxyl_1 = Chain::Vec(
+            Vec::from([Chain::KV("H".into(), 1), Chain::KV("O".into(), 1)]),
+            1,
+        );
+        let hydroxyl_4 = Chain::Vec(
+            Vec::from([Chain::KV("O".into(), 1), Chain::KV("H".into(), 1)]),
+            1,
+        );
+        let methylene = Chain::Vec(
+            Vec::from([Chain::KV("C".into(), 1), Chain::KV("H".into(), 2)]),
+            1,
+        );
+        let chain = Chain::Vec(
+            Vec::from([
+                hydroxyl_1,
+                methylene.clone(),
+                methylene.clone(),
+                methylene.clone(),
+                methylene,
+                hydroxyl_4,
+            ]),
+            1,
+        );
+        assert_eq!(
+            chain.to_string(),
+            "HO(CH2)4OH",
+            "Could not condense 1,4-butanediol into chemical formula"
+        )
+    }
 }

--- a/src/matter/compound/mod.rs
+++ b/src/matter/compound/mod.rs
@@ -170,6 +170,18 @@ impl Compound {
         self.atoms.get(i)
     }
 
+    fn get_atom_unsafe(&self, idx: usize) -> &Atom {
+        if let Some(atom) = self.atoms.get(idx) {
+            atom
+        } else {
+            panic!(
+                "Invalid atom index: {} (length is {})",
+                idx,
+                self.atoms.len(),
+            );
+        }
+    }
+
     fn has_side_chain(&self, i: usize) -> bool {
         if let Some(side_chain) = self.side_chains.get(&i) {
             !side_chain.is_empty()
@@ -178,12 +190,10 @@ impl Compound {
         }
     }
 
-    fn get_sidechain_len(&self, backbone_i: usize) -> CompoundResult<usize> {
-        let side_chain =
-            self.side_chains.get(&backbone_i).ok_or_else(|| {
-                CompoundError::Unknown("Side chain not found.".into())
-            })?;
-        Ok(side_chain.len())
+    fn get_sidechain_len(&self, backbone_i: usize) -> Option<usize> {
+        self.side_chains
+            .get(&backbone_i)
+            .map(|side_chain| side_chain.len())
     }
 
     fn side_chain_as_str(
@@ -208,8 +218,7 @@ impl Compound {
             .side_chains
             .get(&backbone_i)
             .expect("Side chain not found");
-        let mut q: LinkedList<String> = LinkedList::new();
-        // queue
+        let mut q = LinkedList::<String>::new();
         for &i in sorted(side_chain) {
             let atom_str = self
                 .get_atom(i)

--- a/src/matter/compound/mod.rs
+++ b/src/matter/compound/mod.rs
@@ -1,4 +1,5 @@
 pub mod builder;
+pub mod deserializer;
 
 use itertools::sorted;
 use std::{

--- a/src/matter/compound/mod.rs
+++ b/src/matter/compound/mod.rs
@@ -195,6 +195,10 @@ impl Compound {
         Ok(s)
     }
 
+    fn get_sidechain_unsafe(&self, i: usize) -> &BTreeSet<usize> {
+        self.side_chains.get(&i).expect("Side chain not found")
+    }
+
     fn write_side_chain<W: fmt::Write>(
         &self,
         w: &mut W,


### PR DESCRIPTION
This feature uses `Chain`s to fix `Compound`'s `Display` implementation. `Chain`s are intermediary structures used to organize atoms. `Chain`  de-serializes `Compound` into simpler units that can be parsed into strings.

Thus, `Compound` uses `Chain` to create strings.